### PR TITLE
给Artalk增加修改默认时区配置项

### DIFF
--- a/Config.example.php
+++ b/Config.example.php
@@ -2,6 +2,8 @@
 return [
   // 网站名
   'site_name' => 'XXX 的博客',
+  // 时区
+  'TimeZone' => 'Asia/Shanghai',
   // 支持跨域访问的域名
   'allow_origin' => [
     'http://localhost:8080' // 或 '*' 跨域无限制

--- a/app/components/Action.php
+++ b/app/components/Action.php
@@ -77,6 +77,7 @@ trait Action
     $comment->page_key = $pageKey;
     $comment->rid = $rid;
     $comment->ua = $ua;
+    $TimeZone = date_default_timezone_set(_config()['TimeZone']);
     $comment->date = date("Y-m-d H:i:s");
     $comment->ip = $this->getUserIP();
     $comment->is_collapsed = false;


### PR DESCRIPTION
如果后端vps服务器（或者php空间）在国外，发表评论的时间默认将会读取服务器所在地区的时间

此PR主要用于没有权限更改 `php.ini` 的用户

写法可能不好，不过可以解决评论时间不对的问题。只做参考，有待作者合并更新